### PR TITLE
up doc: fix the error name of var in wechat doc

### DIFF
--- a/Cn/Components/WeChat/officialAccount.md
+++ b/Cn/Components/WeChat/officialAccount.md
@@ -85,7 +85,7 @@ $configArray = [
   'appId'     => 'you appId',
   'appSecret' => 'you appSecret',
   'token'     => 'you token',
-  'AesKey'    => 'you AesKey',
+  'aesKey'    => 'you AesKey',
 ];
 $weChatConfig->officialAccount($configArray);
 


### PR DESCRIPTION
up doc: fix the error name of var in wechat doc